### PR TITLE
feat: add --skip-env option to dev and build commands

### DIFF
--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -3,13 +3,19 @@ import { Bundler } from '@mastra/deployer/bundler';
 
 export class BuildBundler extends Bundler {
   private customEnvFile?: string;
+  private skipEnv?: boolean;
 
-  constructor(customEnvFile?: string) {
+  constructor(customEnvFile?: string, skipEnv?: boolean) {
     super('Build');
     this.customEnvFile = customEnvFile;
+    this.skipEnv = skipEnv;
   }
 
   getEnvFiles(): Promise<string[]> {
+    if (this.skipEnv) {
+      return Promise.resolve([]);
+    }
+
     const possibleFiles = ['.env.production', '.env.local', '.env'];
     if (this.customEnvFile) {
       possibleFiles.unshift(this.customEnvFile);

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -11,11 +11,13 @@ export async function build({
   tools,
   root,
   env,
+  skipEnv,
 }: {
   dir?: string;
   tools?: string[];
   root?: string;
   env?: string;
+  skipEnv?: boolean;
 }) {
   const rootDir = root || process.cwd();
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(rootDir, dir)) : join(rootDir, 'src', 'mastra');
@@ -30,7 +32,7 @@ export async function build({
 
     const platformDeployer = await getDeployer(mastraEntryFile, outputDirectory);
     if (!platformDeployer) {
-      const deployer = new BuildBundler(env);
+      const deployer = new BuildBundler(env, skipEnv);
       deployer.__setLogger(logger);
       await deployer.prepare(outputDirectory);
       await deployer.bundle(mastraEntryFile, outputDirectory, discoveredTools);

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -9,13 +9,19 @@ import type { RollupWatcherEvent } from 'rollup';
 
 export class DevBundler extends Bundler {
   private customEnvFile?: string;
+  private skipEnv?: boolean;
 
-  constructor(customEnvFile?: string) {
+  constructor(customEnvFile?: string, skipEnv?: boolean) {
     super('Dev');
     this.customEnvFile = customEnvFile;
+    this.skipEnv = skipEnv;
   }
 
   getEnvFiles(): Promise<string[]> {
+    if (this.skipEnv) {
+      return Promise.resolve([]);
+    }
+
     const possibleFiles = ['.env.development', '.env.local', '.env'];
     if (this.customEnvFile) {
       possibleFiles.unshift(this.customEnvFile);

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -158,6 +158,7 @@ export async function dev({
   env,
   inspect,
   inspectBrk,
+  skipEnv,
 }: {
   dir?: string;
   root?: string;
@@ -166,6 +167,7 @@ export async function dev({
   env?: string;
   inspect?: boolean;
   inspectBrk?: boolean;
+  skipEnv?: boolean;
 }) {
   const rootDir = root || process.cwd();
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(process.cwd(), dir)) : join(process.cwd(), 'src', 'mastra');
@@ -178,7 +180,7 @@ export async function dev({
   const fileService = new FileService();
   const entryFile = fileService.getFirstExistingFile([join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')]);
 
-  const bundler = new DevBundler(env);
+  const bundler = new DevBundler(env, skipEnv);
   bundler.__setLogger(logger);
   await bundler.prepare(dotMastraPath);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -183,6 +183,7 @@ program
   .option('-e, --env <env>', 'Custom env file to include in the dev server')
   .option('-i, --inspect', 'Start the dev server in inspect mode')
   .option('-b, --inspect-brk', 'Start the dev server in inspect mode and break at the beginning of the script')
+  .option('--skip-env', 'Skip loading .env files (useful when using external env injection like dotenvx)')
   .action(args => {
     analytics.trackCommand({
       command: 'dev',
@@ -201,6 +202,7 @@ program
       env: args?.env,
       inspect: args?.inspect && !args?.inspectBrk,
       inspectBrk: args?.inspectBrk,
+      skipEnv: args?.skipEnv,
     }).catch(err => {
       logger.error(err.message);
     });
@@ -213,6 +215,7 @@ program
   .option('-r, --root <path>', 'Path to your root folder')
   .option('-t, --tools <toolsDirs>', 'Comma-separated list of paths to tool files to include')
   .option('-e, --env <env>', 'Custom env file to include in the build')
+  .option('--skip-env', 'Skip loading .env files (useful when using external env injection like dotenvx)')
   .action(async args => {
     await analytics.trackCommandExecution({
       command: 'mastra build',
@@ -223,6 +226,7 @@ program
           root: args?.root,
           tools: args?.tools ? args.tools.split(',') : [],
           env: args?.env,
+          skipEnv: args?.skipEnv,
         });
       },
       origin,


### PR DESCRIPTION
## 🎯 解决问题

解决 issue #5730：`mastra dev` 总是加载 `.env` 文件，覆盖了通过 `dotenvx run` 注入的环境变量。

## 🚀 解决方案

为 `mastra dev` 和 `mastra build` 命令添加了 `--skip-env` 选项，允许用户在使用外部环境变量注入工具（如 dotenvx）时跳过加载本地 `.env` 文件。

## 📝 变更内容

- 在 CLI 命令定义中添加 `--skip-env` 选项
- 修改 `DevBundler` 和 `BuildBundler` 类以支持 `skipEnv` 参数
- 当 `skipEnv=true` 时，`getEnvFiles()` 方法返回空数组，防止加载环境文件
- 保持向后兼容性，默认行为不变

## 🔧 使用方法

```bash
# 使用 dotenvx 注入环境变量，同时跳过本地 .env 文件
dotenvx run -- mastra dev --skip-env
dotenvx run -- mastra build --skip-env
```

## ✅ 测试

- [x] CLI 选项正确显示在帮助信息中
- [x] 代码成功编译和构建
- [x] 类型检查通过
- [x] Lint 检查通过

## 📚 相关 Issue

Closes #5730

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author